### PR TITLE
Fix navmesh performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2025-02-08
+
+**Note:** This release requires `LevelBlock` nodes to be inside `NavigationRegion3D` (or configured with node groups in `NavigationMesh` resource) to be considered for navigation mesh baking. Previous behaviour of navmeshes generating outside `NavigationRegion3D` was incorrect.
+
+### Addded
+
+- Support navigation mesh baking AABB filter
+
+### Fixed
+
+- Improve navigation mesh baking performance
+
 ## [3.0.0] - 2024-12-30
 
 ### Changed
@@ -50,7 +62,7 @@ Further development efforts will primarily be focused on the new version and we 
 
 - Initial release
 
-[unreleased]: https://github.com/Reun-Media/godot-levelblock/compare/3.0.0...HEAD
+[3.0.1]: https://github.com/Reun-Media/godot-levelblock/compare/3.0.0...3.0.1
 [3.0.0]: https://github.com/Reun-Media/godot-levelblock/compare/2.0.0...3.0.0
 [2.0.0]: https://github.com/Reun-Media/godot-levelblock/compare/1.0.2...2.0.0
 [1.0.2]: https://github.com/Reun-Media/godot-levelblock/compare/1.0.1...1.0.2

--- a/addons/level_block/CHANGELOG.md
+++ b/addons/level_block/CHANGELOG.md
@@ -5,36 +5,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.0.1] - 2025-02-08
+
+**Note:** This release requires `LevelBlock` nodes to be inside `NavigationRegion3D` (or configured with node groups in `NavigationMesh` resource) to be considered for navigation mesh baking. Previous behaviour of navmeshes generating outside `NavigationRegion3D` was incorrect.
+
+### Addded
+
+- Support navigation mesh baking AABB filter
+
+### Fixed
+
+- Improve navigation mesh baking performance
+
+## [3.0.0] - 2024-12-30
+
+### Changed
+
+- **Breaking:** Requires Godot 4.3
+
+### Added
+
+- Support baking navigation meshes ([#15](https://github.com/Reun-Media/godot-levelblock/pull/15))
 
 ## [2.0.0] - 2023-06-07 - Godot 4 support
-**🎉 Levelblock has been updated to support Godot 4! 🎉**
+
+**🎉 LevelBlock has been updated to support Godot 4! 🎉**
 
 Check out the [godot-3 branch](https://github.com/Reun-Media/godot-levelblock/tree/godot-3) for 1.x version that supports Godot 3.5.
 
 Further development efforts will primarily be focused on the new version and we can't guarantee new features for Godot 3.5, but if you encounter any bugs feel free to [submit an issue](https://github.com/Reun-Media/godot-levelblock/issues) or [open a pull request](https://github.com/Reun-Media/godot-levelblock/pulls).
 
 ### Added
+
 - Example tileset is bundled with the plugin
 
 ### Changed
+
 - Updated plugin to support Godot 4
 - Smaller Inspector texture preview
 
 ## [1.0.2] - 2022-12-22
+
 ### Fixed
+
 - Global transforms are only set inside scene tree
 - Physics bodies now have object instance attached (enables getting collider via raycasts)
 
 ## [1.0.1] - 2022-12-17
+
 ### Fixed
+
 - Fixed node visibility not being applied
 - Fixed global transformation not being applied
 
 ## [1.0.0] - 2022-12-15
+
 - Initial release
 
-[unreleased]: https://github.com/Reun-Media/godot-levelblock/compare/2.0.0...HEAD
+[3.0.1]: https://github.com/Reun-Media/godot-levelblock/compare/3.0.0...3.0.1
+[3.0.0]: https://github.com/Reun-Media/godot-levelblock/compare/2.0.0...3.0.0
 [2.0.0]: https://github.com/Reun-Media/godot-levelblock/compare/1.0.2...2.0.0
 [1.0.2]: https://github.com/Reun-Media/godot-levelblock/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/Reun-Media/godot-levelblock/compare/1.0.0...1.0.1

--- a/addons/level_block/level_block.gd
+++ b/addons/level_block/level_block.gd
@@ -5,16 +5,22 @@ const Icon = preload("res://addons/level_block/icon.svg")
 const BlockNode = preload("res://addons/level_block/level_block_node.gd")
 const GizmoPlugin = preload("res://addons/level_block/level_block_gizmo.gd")
 const InspectorPlugin = preload("res://addons/level_block/level_block_inspector.gd")
+const NavmeshParser = preload("res://addons/level_block/src/navmesh_parser.gd")
 
 var gizmo_plugin = GizmoPlugin.new()
 var inspector_plugin = InspectorPlugin.new()
+var navmesh_parser = NavmeshParser.new()
 
 func _enter_tree():
 	add_custom_type("LevelBlock", "Node3D", BlockNode, Icon)
 	add_node_3d_gizmo_plugin(gizmo_plugin)
 	add_inspector_plugin(inspector_plugin)
+	
+	navmesh_parser.create_parser()
 
 func _exit_tree():
 	remove_custom_type("LevelBlock")
 	remove_node_3d_gizmo_plugin(gizmo_plugin)
 	remove_inspector_plugin(inspector_plugin)
+	
+	navmesh_parser.delete_parser()

--- a/addons/level_block/level_block_node.gd
+++ b/addons/level_block/level_block_node.gd
@@ -60,7 +60,10 @@ var body
 var mesh
 var shape
 var occluders : Array
+## Stores mesh faces for navmesh generation
 var mesh_faces := PackedVector3Array()
+## Stores mesh AABB for navmesh generation
+var mesh_aabb := AABB()
 
 func _ready():
 	set_notify_transform(true)
@@ -76,8 +79,9 @@ func refresh():
 	
 	mesh = create_mesh()
 	
-	# Store mesh faces for navmesh generation
+	# Store mesh faces and AABB for navmesh generation
 	mesh_faces = mesh.get_faces()
+	mesh_aabb = mesh.get_aabb()
 	
 	mesh.surface_set_material(0, material)
 	material.albedo_texture = texture_sheet

--- a/addons/level_block/level_block_node.gd
+++ b/addons/level_block/level_block_node.gd
@@ -60,6 +60,7 @@ var body
 var mesh
 var shape
 var occluders : Array
+var mesh_faces := PackedVector3Array()
 
 func _ready():
 	set_notify_transform(true)
@@ -72,7 +73,12 @@ func refresh():
 		return
 	if generate_occluders:
 		create_occluders()
+	
 	mesh = create_mesh()
+	
+	# Store mesh faces for navmesh generation
+	mesh_faces = mesh.get_faces()
+	
 	mesh.surface_set_material(0, material)
 	material.albedo_texture = texture_sheet
 	# RenderingServer
@@ -108,6 +114,7 @@ func clear():
 		for o in occluders:
 			o.queue_free()
 	occluders.clear()
+	mesh_faces.clear()
 
 func get_uv_gap() -> float:
 	return float(texture_size) / texture_sheet.get_size().x

--- a/addons/level_block/level_block_node.gd
+++ b/addons/level_block/level_block_node.gd
@@ -61,14 +61,8 @@ var mesh
 var shape
 var occluders : Array
 
-var source_geometry_parser: RID
-var source_geometry_parser_callback: Callable
-
 func _ready():
 	set_notify_transform(true)
-	source_geometry_parser_callback = Callable(self, "_on_source_geometry_parser_callback")
-	source_geometry_parser = NavigationServer3D.source_geometry_parser_create()
-	NavigationServer3D.source_geometry_parser_set_callback(source_geometry_parser, source_geometry_parser_callback)
 	refresh()
 
 func refresh():
@@ -196,17 +190,6 @@ func create_occluders():
 		add_child(occluder)
 		occluders.append(occluder)
 
-func _on_source_geometry_parser_callback(
-	p_navigation_mesh: NavigationMesh,
-	p_source_geometry_data: NavigationMeshSourceGeometryData3D,
-	p_parsed_node: Node) -> void:
-	if generate_collision:
-		p_source_geometry_data.add_mesh(mesh, transform)
-
-func delete_parser() -> void:
-	NavigationServer3D.free_rid(source_geometry_parser)
-	source_geometry_parser = RID()
-
 func _notification(what):
 	match what:
 		NOTIFICATION_TRANSFORM_CHANGED:
@@ -220,4 +203,3 @@ func _enter_tree() -> void:
 
 func _exit_tree() -> void:
 	clear()
-	delete_parser()

--- a/addons/level_block/src/navmesh_parser.gd
+++ b/addons/level_block/src/navmesh_parser.gd
@@ -1,0 +1,37 @@
+@tool
+
+const LevelBlockNode = preload("res://addons/level_block/level_block_node.gd")
+
+var source_geometry_parser: RID
+var source_geometry_parser_callback: Callable
+
+func create_parser() -> void:
+	source_geometry_parser_callback = Callable(
+		self,
+		"_on_source_geometry_parser_callback"
+	)
+	source_geometry_parser = NavigationServer3D.source_geometry_parser_create()
+	NavigationServer3D.source_geometry_parser_set_callback(
+		source_geometry_parser,
+		source_geometry_parser_callback
+	)
+
+func delete_parser() -> void:
+	NavigationServer3D.free_rid(source_geometry_parser)
+	source_geometry_parser = RID()
+	source_geometry_parser_callback = Callable()
+
+func _on_source_geometry_parser_callback(
+	p_navigation_mesh: NavigationMesh,
+	p_source_geometry_data: NavigationMeshSourceGeometryData3D,
+	p_parsed_node: Node) -> void:
+	
+	# Skip navmesh generation for nodes that are not LevelBlock nodes
+	if not p_parsed_node is LevelBlockNode:
+		return
+	
+	# Skip navmesh generation for LevelBlocks without collision
+	if not p_parsed_node.generate_collision:
+		return
+	
+	p_source_geometry_data.add_mesh(p_parsed_node.mesh, p_parsed_node.global_transform)

--- a/addons/level_block/src/navmesh_parser.gd
+++ b/addons/level_block/src/navmesh_parser.gd
@@ -34,4 +34,11 @@ func _on_source_geometry_parser_callback(
 	if not p_parsed_node.generate_collision:
 		return
 	
-	p_source_geometry_data.add_mesh(p_parsed_node.mesh, p_parsed_node.global_transform)
+	# Skip navmesh generation for LevelBlocks with no faces
+	if p_parsed_node.mesh_faces.size() == 0:
+		return
+	
+	p_source_geometry_data.add_faces(
+		p_parsed_node.mesh_faces,
+		p_parsed_node.global_transform
+	)

--- a/addons/level_block/src/navmesh_parser.gd
+++ b/addons/level_block/src/navmesh_parser.gd
@@ -38,6 +38,20 @@ func _on_source_geometry_parser_callback(
 	if p_parsed_node.mesh_faces.size() == 0:
 		return
 	
+	# Skip navmesh generation for LevelBlocks that are outside the
+	# navigation mesh filter baking AABB
+	var filter_baking_aabb := p_navigation_mesh.filter_baking_aabb
+	if filter_baking_aabb.has_volume() && p_parsed_node.mesh_aabb.has_volume():
+		# Offset the mesh AABB by the filter baking AABB offset
+		var filter_baking_aabb_offset := p_navigation_mesh.get_filter_baking_aabb_offset()
+		filter_baking_aabb.position += filter_baking_aabb_offset
+		
+		# Convert the mesh AABB to global space with LevelBlock transfrom
+		var mesh_aabb: AABB = p_parsed_node.global_transform * p_parsed_node.mesh_aabb
+		
+		if not filter_baking_aabb.intersects(mesh_aabb):
+			return
+	
 	p_source_geometry_data.add_faces(
 		p_parsed_node.mesh_faces,
 		p_parsed_node.global_transform

--- a/scenes/level.tscn
+++ b/scenes/level.tscn
@@ -124,269 +124,6 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 2)
 light_color = Color(1, 0.854167, 0.75, 1)
 omni_range = 6.0
 
-[node name="Level" type="Node3D" parent="."]
-
-[node name="LevelBlock" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 0, -2)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("3_c3ffj")
-north_face = 1
-west_face = 0
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock2" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -2)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock10" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -4)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-east_face = 1
-west_face = 2
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock11" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -6)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-east_face = 0
-west_face = 0
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock12" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -8)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-east_face = 0
-west_face = 0
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock13" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -10)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-north_face = 6
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock14" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 0, -10)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-north_face = 0
-south_face = 0
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock15" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, -10)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-north_face = 0
-south_face = 0
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock17" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, -10)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-north_face = 0
-east_face = 7
-south_face = 0
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock16" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 0, -10)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-north_face = 0
-south_face = 0
-west_face = 7
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock3" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, -2)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-north_face = 2
-east_face = 0
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="ButtonBlock" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, 0)
-script = ExtResource("6")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-east_face = 7
-top_face = 5
-bottom_face = 4
-
-[node name="LevelBlock5" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, 2)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-east_face = 0
-south_face = 0
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock6" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 2)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-south_face = 6
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock7" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 0, 2)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-south_face = 0
-west_face = 0
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock8" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 0, 0)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock19" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 0, 0)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-north_face = 0
-south_face = 0
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock20" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -6, 0, 0)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-south_face = 0
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock21" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8, 0, 0)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-south_face = 0
-west_face = 0
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock22" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8, 0, -2)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-north_face = 0
-west_face = 0
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="LevelBlock23" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -6, 0, -2)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-north_face = 0
-east_face = 0
-top_face = 5
-bottom_face = 4
-generate_occluders = true
-
-[node name="FalseWall" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.02381, 0, 0.00627279)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-east_face = 9
-generate_collision = false
-generate_occluders = true
-
-[node name="FalseWall2" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.02381, 0, 0.00627279)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-west_face = 0
-generate_collision = false
-generate_occluders = true
-
-[node name="LevelBlock9" type="Node3D" parent="Level"]
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-bottom_face = 14
-generate_occluders = true
-
-[node name="LevelBlock18" type="Node3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
-script = ExtResource("4")
-material = ExtResource("5")
-texture_sheet = ExtResource("2")
-north_face = 0
-east_face = 0
-south_face = 0
-west_face = 0
-top_face = 15
-generate_occluders = true
-
 [node name="Player" parent="." instance=ExtResource("1")]
 
 [node name="Door" type="AnimatableBody3D" parent="."]
@@ -421,3 +158,266 @@ skeleton = NodePath("../..")
 
 [node name="NavigationRegion3D" type="NavigationRegion3D" parent="."]
 navigation_mesh = SubResource("NavigationMesh_4w2hk")
+
+[node name="Level" type="Node3D" parent="NavigationRegion3D"]
+
+[node name="LevelBlock" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 0, -2)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("3_c3ffj")
+north_face = 1
+west_face = 0
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock2" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -2)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock10" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -4)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+east_face = 1
+west_face = 2
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock11" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -6)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+east_face = 0
+west_face = 0
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock12" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -8)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+east_face = 0
+west_face = 0
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock13" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -10)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+north_face = 6
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock14" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 0, -10)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+north_face = 0
+south_face = 0
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock15" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, -10)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+north_face = 0
+south_face = 0
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock17" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, -10)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+north_face = 0
+east_face = 7
+south_face = 0
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock16" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 0, -10)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+north_face = 0
+south_face = 0
+west_face = 7
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock3" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, -2)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+north_face = 2
+east_face = 0
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="ButtonBlock" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, 0)
+script = ExtResource("6")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+east_face = 7
+top_face = 5
+bottom_face = 4
+
+[node name="LevelBlock5" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, 2)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+east_face = 0
+south_face = 0
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock6" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 2)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+south_face = 6
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock7" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 0, 2)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+south_face = 0
+west_face = 0
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock8" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 0, 0)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock19" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 0, 0)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+north_face = 0
+south_face = 0
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock20" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -6, 0, 0)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+south_face = 0
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock21" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8, 0, 0)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+south_face = 0
+west_face = 0
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock22" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8, 0, -2)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+north_face = 0
+west_face = 0
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="LevelBlock23" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -6, 0, -2)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+north_face = 0
+east_face = 0
+top_face = 5
+bottom_face = 4
+generate_occluders = true
+
+[node name="FalseWall" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.02381, 0, 0.00627279)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+east_face = 9
+generate_collision = false
+generate_occluders = true
+
+[node name="FalseWall2" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.02381, 0, 0.00627279)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+west_face = 0
+generate_collision = false
+generate_occluders = true
+
+[node name="LevelBlock9" type="Node3D" parent="NavigationRegion3D/Level"]
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+bottom_face = 14
+generate_occluders = true
+
+[node name="LevelBlock18" type="Node3D" parent="NavigationRegion3D/Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0)
+script = ExtResource("4")
+material = ExtResource("5")
+texture_sheet = ExtResource("2")
+north_face = 0
+east_face = 0
+south_face = 0
+west_face = 0
+top_face = 15
+generate_occluders = true


### PR DESCRIPTION
This PR aims to fix navmesh baking performance issues described in [this comment](https://github.com/Reun-Media/godot-levelblock/pull/15#issuecomment-2600102040). Fixes #17.

## ✅ TODO
- [x] Use a single parser for all LevelBlock nodes
- [x] Use `add_faces` instead of `add_mesh` to add vertices to navmesh directly and avoid GPU overhead
- [X] Support navmesh filter baking AABB
- [x] ~Support navmesh collision layers~
  - Blocked by #19. Might implement later.